### PR TITLE
Fetch resources and list GPU + Client abstraction.

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,12 +21,19 @@ func newListCmd() *cobra.Command {
 		RunE: Run,
 	}
 
+	//flag = listCmd.Flags().BoolVarP("")
+
 	return listCmd
 }
 
 func Run(cmd *cobra.Command, args []string) error {
-	namespaceList := k8s.GetNamespaceList(k8s.GetClientset())
-	userList := user.PopulateList(namespaceList)
+	client, err := k8s.NewClient()
+
+	if err != nil {
+		return err
+	}
+
+	userList, err := user.PopulateList(client)
 
 	renderUsers(userList)
 
@@ -40,6 +47,9 @@ func renderUsers(userList []user.User) {
 		"E-mail",
 		"User type",
 		"Status",
+		"GPU",
+		"|Max",
+		"Used|",
 	}
 
 	userTable := user.ListToTable(userList)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -3,28 +3,38 @@ package k8s
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func GetClientset() *kubernetes.Clientset {
+type Client interface {
+	GetNamespaceList() (*corev1.NamespaceList, error)
+	GetResourceQuota(string) (ResourceQuota, error)
+	GetDefaultRequest(string) (ResourceRequest, error)
+}
+
+type K8sClient struct {
+	Clientset *kubernetes.Clientset
+}
+
+func NewClient() (Client, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
 	config, err := kubeconfig.ClientConfig()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return kubernetes.NewForConfigOrDie(config)
+	return &K8sClient{kubernetes.NewForConfigOrDie(config)}, nil
 }
 
-func GetNamespaceList(clientset *kubernetes.Clientset) *v1.NamespaceList {
-	namespaceList, err := clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+func (c *K8sClient) GetNamespaceList() (*corev1.NamespaceList, error) {
+	namespaceList, err := c.Clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return namespaceList
+	return namespaceList, nil
 }

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -1,0 +1,65 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type resourceSummary struct {
+	Max  string
+	Used string
+}
+
+type ResourceQuota struct {
+	CPU    resourceSummary
+	GPU    resourceSummary
+	Memory resourceSummary
+}
+
+type ResourceRequest struct {
+	CPU    string
+	GPU    string
+	Memory string
+}
+
+func (c *K8sClient) GetResourceQuota(namespace string) (ResourceQuota, error) {
+	res, err := c.Clientset.CoreV1().ResourceQuotas(namespace).List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		return ResourceQuota{}, err
+	}
+
+	rq := ResourceQuota{
+		CPU: resourceSummary{
+			Max:  fmt.Sprint(res.Items[0].Spec.Hard["requests.cpu"].ToUnstructured()),
+			Used: fmt.Sprint(res.Items[0].Status.Used["requests.cpu"].ToUnstructured()),
+		},
+		GPU: resourceSummary{
+			Max:  fmt.Sprint(res.Items[0].Spec.Hard["requests.nvidia.com/gpu"].ToUnstructured()),
+			Used: fmt.Sprint(res.Items[0].Status.Used["requests.nvidia.com/gpu"].ToUnstructured()),
+		},
+		Memory: resourceSummary{
+			Max:  fmt.Sprint(res.Items[0].Spec.Hard["requests.memory"].ToUnstructured()),
+			Used: fmt.Sprint(res.Items[0].Status.Used["requests.memory"].ToUnstructured()),
+		},
+	}
+
+	return rq, nil
+}
+
+func (c *K8sClient) GetDefaultRequest(namespace string) (ResourceRequest, error) {
+	res, err := c.Clientset.CoreV1().LimitRanges(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return ResourceRequest{}, err
+	}
+
+	rr := ResourceRequest{
+		CPU:    fmt.Sprint(res.Items[0].Spec.Limits[0].DefaultRequest["cpu"].ToUnstructured()),
+		GPU:    fmt.Sprint(res.Items[0].Spec.Limits[0].DefaultRequest["nvidia.com/gpu"].ToUnstructured()),
+		Memory: fmt.Sprint(res.Items[0].Spec.Limits[0].DefaultRequest["memory"].ToUnstructured()),
+	}
+
+	return rr, nil
+}


### PR DESCRIPTION
Implemented fetching resource quota for each user (ref issue #1). This is fetched when the user info is populated. Not optional at the moment, but it should probably be as it slows down the process. Right now, only GPU is shown in `ls`, but memory and CPU is still stored. I also implemented some k8s client abstractions. 