### PR TITLE
List resources

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -12,16 +12,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var listResources bool
+
 // listCmd represents the list command
 func newListCmd() *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "ls",
-		Short: "List all springfield users",
+		Short: "List all Springfield users.",
 
 		RunE: Run,
 	}
 
-	//flag = listCmd.Flags().BoolVarP("")
+	listCmd.Flags().BoolVarP(&listResources, "show-resources", "r", false, "Show resources for all users.")
 
 	return listCmd
 }
@@ -33,7 +35,7 @@ func Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	userList, err := user.PopulateList(client)
+	userList, err := user.PopulateList(client, listResources)
 
 	if err != nil {
 		return err
@@ -51,10 +53,13 @@ func renderUsers(userList []user.User) {
 		"E-mail",
 		"User type",
 		"Status",
-		"GPU",
 	}
 
-	userTable := user.ListToTable(userList)
+	if listResources {
+		headerList = append(headerList, "GPU")
+	}
+
+	userTable := user.ListToTable(userList, listResources)
 
 	cli.RenderTable(headerList, userTable)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,6 +35,10 @@ func Run(cmd *cobra.Command, args []string) error {
 
 	userList, err := user.PopulateList(client)
 
+	if err != nil {
+		return err
+	}
+
 	renderUsers(userList)
 
 	return nil
@@ -48,8 +52,6 @@ func renderUsers(userList []user.User) {
 		"User type",
 		"Status",
 		"GPU",
-		"|Max",
-		"Used|",
 	}
 
 	userTable := user.ListToTable(userList)

--- a/internal/user/userdef.go
+++ b/internal/user/userdef.go
@@ -72,9 +72,7 @@ func ListToTable(userList []User) [][]string {
 			user.Email,
 			user.Usertype,
 			user.Status,
-			"",
-			"| " + user.ResourceQuota.GPU.Max,
-			"  " + user.ResourceQuota.GPU.Used + " |",
+			user.ResourceQuota.GPU.Used + "/" + user.ResourceQuota.GPU.Max,
 		})
 	}
 


### PR DESCRIPTION
Ref #1 . Resources are now only shown if the flag `-r` or `--show-resources` is used on the `ls` command. Polling the resources is slow, so it should be optional to fetch them. Also improved the readability of the terminal output for resources.