### PR TITLE
Memory per GPU: Int division instead of formula.

### DIFF
--- a/internal/user/resources.go
+++ b/internal/user/resources.go
@@ -19,7 +19,7 @@ func memoryPerGPU(usr *User) string {
 		panic(err)
 	}
 
-	memoryPerGPU := (memory - 256) / (GPUMax * 1024)
+	memoryPerGPU := memory / (GPUMax * 1024)
 
 	return fmt.Sprint(memoryPerGPU) + "Gi"
 }


### PR DESCRIPTION
Ref #8. I decided to go with the int division instead of the formula. It avoids the issue of dealing with the extra memory for the SSH server.