### PR TITLE
Implemented delete user + tests

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/uitml/quimby/internal/cli"
+	"github.com/uitml/quimby/internal/k8s"
+	"github.com/uitml/quimby/internal/validate"
+)
+
+// listCmd represents the list command
+func newDeleteCmd() *cobra.Command {
+	var deleteCmd = &cobra.Command{
+		Use:   "rm",
+		Short: "Delete user",
+
+		RunE: RunDelete,
+	}
+
+	return deleteCmd
+}
+
+func RunDelete(cmd *cobra.Command, args []string) error {
+	user := args[0]
+
+	// Validate input
+	if !validate.Username(user) {
+		return errors.Errorf("%s is not a valid username", user)
+	}
+
+	client, err := k8s.NewClient()
+	if err != nil {
+		return err
+	}
+
+	v, err := client.UserExists(user)
+	if err != nil {
+		return err
+	}
+	if !v {
+		return errors.Errorf("user %s does not exist", user)
+	}
+
+	// Need confirmation
+	c, err := cli.Confirmation("Do you really want to delete user "+user+"? This action is irreversible.", false)
+	if err != nil {
+		return err
+	}
+	if !c {
+		fmt.Printf("User %s not deleted.\n", user)
+		return nil
+	}
+
+	// Do the dirty work and pray...
+	err = client.DeleteUser(user)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("User %s successfully deleted. Persistent volumes must be removed manually.", user)
+
+	return nil
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -86,12 +86,12 @@ func renderUsers(userList []user.User, footer [][]string) error {
 }
 
 func makeFooter(userList []user.User, client k8s.ResourceClient) ([][]string, error) {
-	totalGPUs, err := client.GetTotalGPUs()
+	GPUSummary, err := client.GetTotalGPUs()
 	if err != nil {
 		return nil, err
 	}
 
-	resourcesUsed := user.TotalResourcesUsed(userList)
+	resourceUsage := user.TotalResourcesUsed(userList)
 
 	footer := [][]string{
 		{
@@ -99,7 +99,7 @@ func makeFooter(userList []user.User, client k8s.ResourceClient) ([][]string, er
 			"",
 			"",
 			"Total:",
-			fmt.Sprint(resourcesUsed[k8s.ResourceGPU]) + "/" + fmt.Sprint(totalGPUs),
+			fmt.Sprint(resourceUsage[k8s.ResourceGPU]) + "/" + fmt.Sprint(GPUSummary.Max),
 			"",
 			"",
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ func newRootCmd() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(newListCmd())
+	rootCmd.AddCommand(newDeleteCmd())
 
 	return rootCmd
 }

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -51,4 +52,34 @@ func RenderTable(table ...[][]string) {
 	defer w.Flush()
 
 	fmt.Fprint(w, formatTable(table))
+}
+
+// Prompts the user for a confirmation [yes/no].
+// Returns true/false if the user answers yes/no.
+// Default choice defined by 'def'
+func Confirmation(str string, def bool) (bool, error) {
+	var defAns string
+	reader := bufio.NewReader(os.Stdin)
+
+	switch def {
+	case true:
+		defAns = "[Y/n]"
+	case false:
+		defAns = "[y/N]"
+	}
+	fmt.Printf("%s %s: ", str, defAns)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	answer = strings.ToLower(strings.TrimSpace(answer))
+
+	if answer == "y" || answer == "yes" {
+		return true, nil
+	} else if answer == "n" || answer == "no" {
+		return false, nil
+	}
+
+	return def, nil
 }

--- a/internal/fake/resources.go
+++ b/internal/fake/resources.go
@@ -107,7 +107,7 @@ func newNode(name string, gpus int64, isUnschedulable bool) corev1.Node {
 		TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       corev1.NodeSpec{Unschedulable: isUnschedulable},
-		Status:     corev1.NodeStatus{Capacity: capacity},
+		Status:     corev1.NodeStatus{Capacity: capacity, Allocatable: capacity},
 	}
 
 	return node

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -10,7 +10,9 @@ type ResourceClient interface {
 	GetNamespaceList() (*corev1.NamespaceList, error)
 	GetResourceQuota(string) (ResourceQuota, error)
 	GetDefaultRequest(string) (ResourceRequest, error)
-	GetTotalGPUs() (int64, error)
+	GetTotalGPUs() (ResourceSummary, error)
+	UserExists(string) (bool, error)
+	DeleteUser(string) error
 }
 
 type Client struct {

--- a/internal/k8s/resources_test.go
+++ b/internal/k8s/resources_test.go
@@ -149,14 +149,14 @@ func TestClient_GetTotalGPUs(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		want    int64
+		want    ResourceSummary
 		wantErr bool
 	}{
 		// Testcase 1: Empty node list. Should return zero
 		{
 			name:    "No nodes",
 			fields:  fields{fake.NewSimpleClientset()},
-			want:    0,
+			want:    ResourceSummary{Max: 0, Used: 0},
 			wantErr: false,
 		},
 		// Testcase 2: 3 servers, 2 with GPUs
@@ -165,7 +165,7 @@ func TestClient_GetTotalGPUs(t *testing.T) {
 			fields: fields{fake.NewSimpleClientset(
 				internalfake.NewNodeList([]string{"foo", "bar", "baz"}, []int64{0, 8, 7}, []bool{false, false, false}),
 			)},
-			want:    15,
+			want:    ResourceSummary{Max: 15, Used: 0},
 			wantErr: false,
 		},
 		// Testcase 3: 3 servers, 2 with GPUs, but one is unschedulable
@@ -174,7 +174,7 @@ func TestClient_GetTotalGPUs(t *testing.T) {
 			fields: fields{fake.NewSimpleClientset(
 				internalfake.NewNodeList([]string{"foo", "bar", "baz"}, []int64{0, 8, 7}, []bool{false, false, true}),
 			)},
-			want:    8,
+			want:    ResourceSummary{Max: 8, Used: 0},
 			wantErr: false,
 		},
 	}

--- a/internal/k8s/users_test.go
+++ b/internal/k8s/users_test.go
@@ -1,0 +1,128 @@
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestClient_UserExists(t *testing.T) {
+	type fields struct {
+		Clientset kubernetes.Interface
+	}
+	type args struct {
+		u string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		// Testcase 1: User exists
+		{
+			name: "User exists",
+			fields: fields{
+				Clientset: fake.NewSimpleClientset(
+					NewNamespace(
+						"foo123",
+						map[string]string{},
+						map[string]string{},
+					),
+				),
+			},
+			args:    args{u: "foo123"},
+			want:    true,
+			wantErr: false,
+		},
+		// Testcase 2: User does not exist
+		{
+			name: "User does not exist",
+			fields: fields{
+				Clientset: fake.NewSimpleClientset(
+					NewNamespace(
+						"foo123",
+						map[string]string{},
+						map[string]string{},
+					),
+				),
+			},
+			args:    args{u: "bar113"},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				Clientset: tt.fields.Clientset,
+			}
+			got, err := c.UserExists(tt.args.u)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.UserExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Client.UserExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_DeleteUser(t *testing.T) {
+	type fields struct {
+		Clientset kubernetes.Interface
+	}
+	type args struct {
+		u string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// Testcase 1: User exists
+		{
+			name: "User exists",
+			fields: fields{
+				Clientset: fake.NewSimpleClientset(
+					NewNamespace(
+						"foo123",
+						map[string]string{},
+						map[string]string{},
+					),
+				),
+			},
+			args:    args{u: "foo123"},
+			wantErr: false,
+		},
+		// Testcase 2: User does not exist
+		{
+			name: "User does not exist",
+			fields: fields{
+				Clientset: fake.NewSimpleClientset(
+					NewNamespace(
+						"foo123",
+						map[string]string{},
+						map[string]string{},
+					),
+				),
+			},
+			args:    args{u: "bar113"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				Clientset: tt.fields.Clientset,
+			}
+			if err := c.DeleteUser(tt.args.u); (err != nil) != tt.wantErr {
+				t.Errorf("Client.DeleteUser() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Quimby is now able to delete users. Implemented (some) tests as well. User must confirm the deletion before they are deleted. Persistent volumes need to be deleted manually after deleting the user.