### PR TITLE
Goroutines & TotalGPUs

### DIFF
--- a/cmd/edit/quota.go
+++ b/cmd/edit/quota.go
@@ -54,14 +54,14 @@ func RunQuota(cmd *cobra.Command, args []string) error {
 	}
 
 	// Selecting which values are allowed to be edited...
-	tmpspec := resource.Spec{
+	tmpSpec := resource.Spec{
 		GPU:                 spec.GPU,
 		MaxMemoryPerJob:     spec.MaxMemoryPerJob,
 		DefaultMemoryPerJob: spec.DefaultMemoryPerJob,
 	}
 
 	// Edit values
-	s, err := yaml.Marshal(tmpspec)
+	s, err := yaml.Marshal(tmpSpec)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/editor.go
+++ b/internal/cli/editor.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Editor(in []byte) ([]byte, error) {
-	// First test: open a temporary file with VI and read the saved file.
+	// Open a temporary file with VI and read the saved file.
 	tmp, err := ioutil.TempFile("", "")
 	if err != nil {
 		return nil, err
@@ -19,7 +19,6 @@ func Editor(in []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	// Open the file in VI and read the result
 	command := exec.Command("vi", tmp.Name())
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
@@ -28,7 +27,7 @@ func Editor(in []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	// Process the file and apply the values
+	// Process the file and return the values
 	res, err := ioutil.ReadFile(tmp.Name())
 	if err != nil {
 		return nil, err

--- a/internal/k8s/apply.go
+++ b/internal/k8s/apply.go
@@ -37,37 +37,37 @@ func (c *Client) Apply(namespace string, manifest []byte) error {
 
 	// Configure patches
 	for _, m := range res {
-		if strings.Contains(string(m), "Namespace") {
+		if strings.Contains(string(m), "kind: Namespace") {
 			err := c.applyNamespace(namespace, m)
 			if err != nil {
 				return err
 			}
-		} else if strings.Contains(string(m), "RoleBinding") {
+		} else if strings.Contains(string(m), "kind: RoleBinding") {
 			err := c.applyRoleBinding(namespace, m)
 			if err != nil {
 				return err
 			}
-		} else if strings.Contains(string(m), "ResourceQuota") {
+		} else if strings.Contains(string(m), "kind: ResourceQuota") {
 			err := c.applyResourceQuota(namespace, m)
 			if err != nil {
 				return err
 			}
-		} else if strings.Contains(string(m), "LimitRange") {
+		} else if strings.Contains(string(m), "kind: LimitRange") {
 			err := c.applyLimitRange(namespace, m)
 			if err != nil {
 				return err
 			}
-		} else if strings.Contains(string(m), "PersistentVolumeClaim") {
+		} else if strings.Contains(string(m), "kind: PersistentVolumeClaim") {
 			err := c.applyPersistentVolumeClaim(namespace, m)
 			if err != nil {
 				return err
 			}
-		} else if strings.Contains(string(m), "Deployment") {
+		} else if strings.Contains(string(m), "kind: Deployment") {
 			err := c.applyDeployment(namespace, m)
 			if err != nil {
 				return err
 			}
-		} else if strings.Contains(string(m), "Service") {
+		} else if strings.Contains(string(m), "kind: Service") {
 			err := c.applyService(namespace, m)
 			if err != nil {
 				return err

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -263,9 +263,23 @@ func (c *Client) TotalGPUs() (resource.Summary, error) {
 	}
 
 	for _, node := range nodes.Items {
+		var nodeReady bool = true
+		for _, condition := range node.Status.Conditions {
+			if condition.Type != corev1.NodeReady {
+				continue
+			}
+			if condition.Status != corev1.ConditionTrue {
+				nodeReady = false
+			}
+			break
+		}
+		if !nodeReady {
+			continue
+		}
 		if node.Spec.Unschedulable {
 			continue
 		}
+
 		// Ignoring errors here since some nodes might not have all resources
 		g, _ := resourceAsInt64(node.Status.Capacity, ResourceGPU)
 		totalGPUs += g[ResourceGPU]

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openlyinc/pointy"
 	"github.com/uitml/quimby/internal/resource"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -44,25 +45,20 @@ func resourceAsInt64(resources corev1.ResourceList, names ...corev1.ResourceName
 
 func (c *Client) Quota(namespace string) (resource.Quota, error) {
 	// Compute
-	res, err := c.Clientset.CoreV1().ResourceQuotas(namespace).List(context.TODO(), metav1.ListOptions{})
+	res, err := c.Clientset.CoreV1().ResourceQuotas(namespace).Get(context.TODO(), "compute-resources", metav1.GetOptions{})
 	if err != nil {
 		return resource.Quota{}, err
 	}
 
-	// Check if user exists
-	if len(res.Items) == 0 {
-		return resource.Quota{}, fmt.Errorf("user %s has no resources or does not exist", namespace)
-	}
-
 	// Storage
-	pvc, err := c.Clientset.CoreV1().PersistentVolumeClaims(namespace).List(context.TODO(), metav1.ListOptions{})
+	pvc, err := c.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), "storage", metav1.GetOptions{})
 	if err != nil {
 		return resource.Quota{}, err
 	}
 
 	// Convert all resources to Int64
 	maxResources, err := resourceAsInt64(
-		res.Items[0].Spec.Hard,
+		res.Spec.Hard,
 		ResourceRequestsGPU,
 		corev1.ResourceRequestsCPU,
 		corev1.ResourceRequestsMemory,
@@ -72,7 +68,7 @@ func (c *Client) Quota(namespace string) (resource.Quota, error) {
 	}
 
 	usedResources, err := resourceAsInt64(
-		res.Items[0].Status.Used,
+		res.Status.Used,
 		ResourceRequestsGPU,
 		corev1.ResourceRequestsCPU,
 		corev1.ResourceRequestsMemory,
@@ -82,7 +78,7 @@ func (c *Client) Quota(namespace string) (resource.Quota, error) {
 	}
 
 	storage, err := resourceAsInt64(
-		pvc.Items[0].Spec.Resources.Requests,
+		pvc.Spec.Resources.Requests,
 		corev1.ResourceStorage,
 	)
 	if err != nil {
@@ -109,79 +105,110 @@ func (c *Client) Quota(namespace string) (resource.Quota, error) {
 }
 
 func (c *Client) Spec(namespace string) (*resource.Spec, error) {
-	// Compute
-	res, err := c.Clientset.CoreV1().ResourceQuotas(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
+	errchan := make(chan error)
 
-	// Check if user exists
-	if len(res.Items) == 0 {
-		return nil, fmt.Errorf("user %s has no resources or does not exist", namespace)
-	}
+	// Compute
+	reschan := make(chan *corev1.ResourceQuota)
+	go func() {
+		res, err := c.Clientset.CoreV1().ResourceQuotas(namespace).Get(context.TODO(), "compute-resources", metav1.GetOptions{})
+		if err != nil {
+			errchan <- err
+		}
+		reschan <- res
+	}()
 
 	// Limits
-	lim, err := c.Clientset.CoreV1().LimitRanges(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
+	limchan := make(chan *corev1.LimitRange)
+	go func() {
+		lim, err := c.Clientset.CoreV1().LimitRanges(namespace).Get(context.TODO(), "default-resources", metav1.GetOptions{})
+		if err != nil {
+			errchan <- err
+		}
+		limchan <- lim
+	}()
 
 	// Storage
-	pvc, err := c.Clientset.CoreV1().PersistentVolumeClaims(namespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
+	pvcchan := make(chan *corev1.PersistentVolumeClaim)
+	go func() {
+		pvc, err := c.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), "storage", metav1.GetOptions{})
+		if err != nil {
+			errchan <- err
+		}
+		pvcchan <- pvc
+	}()
 
 	// storage-proxy
-	dpl, err := c.Clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "storage-proxy", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
+	proxychan := make(chan *appsv1.Deployment)
+	go func() {
+		dpl, err := c.Clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "storage-proxy", metav1.GetOptions{})
+		if err != nil {
+			errchan <- err
+		}
+		proxychan <- dpl
+	}()
 
-	// Convert all resources to Int64
-	maxResources, err := resourceAsInt64(
-		res.Items[0].Spec.Hard,
-		ResourceRequestsGPU,
-		corev1.ResourceRequestsCPU,
-		corev1.ResourceRequestsMemory,
-	)
-	if err != nil {
-		return nil, err
-	}
+	var maxResources, defaultLimits, storage, proxy, proxyrequest map[corev1.ResourceName]int64
+	var err error
+	// Receive and convert all resources to Int64
+	for i := 0; i < 4; i++ {
+		select {
+		case res := <-reschan:
+			maxResources, err = resourceAsInt64(
+				res.Spec.Hard,
+				ResourceRequestsGPU,
+				corev1.ResourceRequestsCPU,
+				corev1.ResourceRequestsMemory,
+			)
+			if err != nil {
+				return nil, err
+			}
 
-	defaultLimits, err := resourceAsInt64(
-		lim.Items[0].Spec.Limits[0].Default,
-		corev1.ResourceCPU,
-		corev1.ResourceMemory,
-		ResourceGPU,
-	)
-	if err != nil {
-		return nil, err
-	}
+			continue
+		case lim := <-limchan:
+			defaultLimits, err = resourceAsInt64(
+				lim.Spec.Limits[0].Default,
+				corev1.ResourceCPU,
+				corev1.ResourceMemory,
+				ResourceGPU,
+			)
+			if err != nil {
+				return nil, err
+			}
 
-	storage, err := resourceAsInt64(
-		pvc.Items[0].Spec.Resources.Requests,
-		corev1.ResourceStorage,
-	)
-	if err != nil {
-		return nil, err
-	}
+			continue
+		case pvc := <-pvcchan:
+			storage, err = resourceAsInt64(
+				pvc.Spec.Resources.Requests,
+				corev1.ResourceStorage,
+			)
+			if err != nil {
+				return nil, err
+			}
 
-	proxy, err := resourceAsInt64(
-		dpl.Spec.Template.Spec.Containers[0].Resources.Limits,
-		corev1.ResourceCPU,
-		corev1.ResourceMemory,
-	)
-	if err != nil {
-		return nil, err
-	}
+			continue
+		case dpl := <-proxychan:
+			proxy, err = resourceAsInt64(
+				dpl.Spec.Template.Spec.Containers[0].Resources.Limits,
+				corev1.ResourceCPU,
+				corev1.ResourceMemory,
+			)
+			if err != nil {
+				return nil, err
+			}
 
-	proxyrequest, err := resourceAsInt64(
-		dpl.Spec.Template.Spec.Containers[0].Resources.Requests,
-		corev1.ResourceCPU,
-	)
-	if err != nil {
-		return nil, err
+			proxyrequest, err = resourceAsInt64(
+				dpl.Spec.Template.Spec.Containers[0].Resources.Requests,
+				corev1.ResourceCPU,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			continue
+		case err := <-errchan:
+			close(errchan)
+			return nil, err
+		}
 	}
 
 	// This is a hot mess


### PR DESCRIPTION
I implemented goroutines (Issue #20) to fetch default values concurrently for `quimby edit quota`. I tested using goroutines for `quimby ls -r` as well, but there are so many requests that k8s throttles the responses (a warning shows up from the API). This is possible to adjust in the cluster settings, but I just reverted to the normal sequential requests.

I also implemented a check to see if nodes are ready when counting the total number of GPUs in the cluster (Issue #11).